### PR TITLE
727. Minimum Window Subsequence

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/.idea/leetcode.iml
+++ b/.idea/leetcode.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/leetcode.iml" filepath="$PROJECT_DIR$/.idea/leetcode.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/Premium/727. Minimum Window Subsequence.java
+++ b/Premium/727. Minimum Window Subsequence.java
@@ -1,0 +1,49 @@
+// 727. Minimum Window Subsequence - HARD
+
+// Given strings s1 and s2, return the minimum contiguous substring part of s1,
+// so that s2 is a subsequence of the part.
+// If there is no such window in s1 that covers all characters in s2,
+// return the empty string "".
+// If there are multiple such minimum-length windows, return the one with the left-most starting index.
+
+// Example 1:
+// Input: s1 = "abcdebdde", s2 = "bde"
+// Output: "bcde"
+// Explanation:
+// "bcde" is the answer because it occurs before "bdde" which has the same length.
+// "deb" is not a smaller window because the elements of s2 in the window must occur in order.
+
+// Example 2:
+// Input: s1 = "jmeqksfrsdcmsiwvaovztaqenprpvnbstl", s2 = "u"
+// Output: ""
+class Solution727 {
+    public String minWindow(String s1, String s2) {
+        int i = 0, j = 0;
+        int ans = s1.length() + 1, idx = -1;
+        while(i < s1.length()){
+            if(s1.charAt(i) == s2.charAt(j)){
+                j++;
+                if(j == s2.length()){ // found the right bound
+                    int right = i;
+                    // restore j position to the last index of s2
+                    j--;
+                    while(j >= 0){ // try to found the nearest left bound starting from right
+                        while(s1.charAt(i) != s2.charAt(j))
+                            i--;
+                        i--;
+                        j--;
+                    }
+                    // restore i and j positions to the first index of s1 and s2
+                    j++;
+                    i++;
+                    if(right - i + 1 < ans){
+                        ans = right - i + 1;
+                        idx = i;
+                    }
+                }
+            }
+            i++;
+        }
+        return idx == -1 ? "" : s1.substring(idx, idx + ans);
+    }
+}


### PR DESCRIPTION
# 727. Minimum Window Subsequence
Given strings `s1` and `s2`, return the minimum _contiguous substring part_ of `s1`, so that `s2` is a subsequence of the part.

If there is no such window in `s1` that covers all characters in `s2`, return the empty string `""`. If there are multiple such minimum-length windows, return the one with the **left-most starting index**.

### Example 1:
> **Input**: s1 = "abcdebdde", s2 = "bde"
**Output**: "bcde"
**Explanation**: 
"bcde" is the answer because it occurs before "bdde" which has the same length.
"deb" is not a smaller window because the elements of s2 in the window must occur in order.
### Example 2:
> **Input**: s1 = "jmeqksfrsdcmsiwvaovztaqenprpvnbstl", s2 = "u"
**Output**: ""
 

### Constraints:
- `1 <= s1.length <= 2 * 104`
- `1 <= s2.length <= 100`
- `s1` and `s2` consist of lowercase English letters.